### PR TITLE
audit: bump Lambda runtime, tighten IAM, honest README, add CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "terraform"
+    directory: "/modules/sagemaker-platform"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "terraform"
+
+  - package-ecosystem: "terraform"
+    directory: "/examples/basic"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "terraform"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TF_VERSION: "1.9.8"
+  TF_VERSION: "1.15.1"
   TF_IN_AUTOMATION: "true"
 
 jobs:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,9 +24,9 @@ jobs:
     name: terraform fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -37,9 +37,9 @@ jobs:
     name: terraform validate (examples/basic)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -55,9 +55,9 @@ jobs:
     name: tflint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@v6
         with:
           tflint_version: latest
 
@@ -76,10 +76,10 @@ jobs:
     name: trivy config scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
           scan-ref: .
@@ -88,7 +88,7 @@ jobs:
           exit-code: "0"
 
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,95 @@
+name: terraform
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TF_VERSION: "1.9.8"
+  TF_IN_AUTOMATION: "true"
+
+jobs:
+  fmt:
+    name: terraform fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: terraform fmt -check -recursive
+        run: terraform fmt -check -recursive
+
+  validate:
+    name: terraform validate (examples/basic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: terraform init -backend=false
+        working-directory: examples/basic
+        run: terraform init -backend=false
+
+      - name: terraform validate
+        working-directory: examples/basic
+        run: terraform validate -no-color
+
+  tflint:
+    name: tflint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: tflint --version
+        run: tflint --version
+
+      - name: tflint --init
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: tflint --recursive
+        run: tflint --recursive --format compact
+
+  trivy:
+    name: trivy config scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy config scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: "0"
+
+      - name: Upload Trivy SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-config

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+*.tfvars
+*.tfvars.json
+.terraform/
+.terraform.tfstate.lock.info
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
+# Lockfile is intentionally tracked
+!.terraform.lock.hcl
+
+# Build artefacts
+*.zip
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# Secrets
+.env
+.env.*
+!.env.example
+*.pem
+*.key

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owner for everything in this repository.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+*       @melorga

--- a/README.md
+++ b/README.md
@@ -1,314 +1,117 @@
-# 🤖 MLOps Platform on AWS
+# ml-platform-aws
 
-[![MLOps](https://img.shields.io/badge/MLOps-Platform-blue?style=for-the-badge&logo=amazon-aws)](https://github.com/melorga/ml-platform-aws)
-[![Terraform](https://img.shields.io/badge/Terraform-1.8+-purple?style=for-the-badge&logo=terraform)](https://terraform.io)
-[![SageMaker](https://img.shields.io/badge/Amazon-SageMaker-orange?style=for-the-badge&logo=amazon-aws)](https://aws.amazon.com/sagemaker/)
-[![EKS](https://img.shields.io/badge/Amazon-EKS-orange?style=for-the-badge&logo=kubernetes)](https://aws.amazon.com/eks/)
+> **Status: experimental, single-module reference implementation.**
+> This repository ships one Terraform module. It is a portfolio / reference
+> example, not a production-ready platform. Treat it as a starting point.
 
-A comprehensive, enterprise-grade MLOps platform built on AWS services that demonstrates end-to-end machine learning lifecycle management with automated training, validation, deployment, and monitoring.
+A Terraform module that provisions a small SageMaker footprint on AWS:
 
-## 🏗️ Architecture Overview
+- **SageMaker Studio Domain** (IAM auth) with configurable user profiles
+- **Model Registry** (Model Package Groups)
+- **S3 buckets** for SageMaker artifacts, Feature Store offline storage, and
+  Model Monitor output (KMS-encrypted, versioned, public access blocked)
+- **KMS key** dedicated to the platform, scoped to the SageMaker service
+- **CloudWatch Log Groups** for training / endpoint / processing jobs
+- **EventBridge -> Lambda -> SNS** pipeline that forwards SageMaker Model
+  Monitor execution status changes as alerts
+- **IAM roles** for SageMaker execution, Feature Store, Step Functions, and
+  SageMaker Pipelines, written as least-privilege inline policies (no
+  `AmazonSageMakerFullAccess` attachment)
 
-```mermaid
-graph TB
-    subgraph "Data Layer"
-        S3[(S3 Data Lake)]
-        FS[SageMaker Feature Store]
-        RDS[(RDS Metadata)]
-    end
-    
-    subgraph "ML Development"
-        SM[SageMaker Studio]
-        NB[Notebooks]
-        EXP[Experiments]
-    end
-    
-    subgraph "ML Pipeline"
-        SF[Step Functions]
-        SP[SageMaker Pipelines]
-        MR[Model Registry]
-    end
-    
-    subgraph "Model Serving"
-        EP[SageMaker Endpoints]
-        EKS[EKS Cluster]
-        ALB[Application Load Balancer]
-    end
-    
-    subgraph "Monitoring & Ops"
-        CW[CloudWatch]
-        MM[Model Monitor]
-        XR[X-Ray Tracing]
-    end
-    
-    S3 --> FS
-    FS --> SM
-    SM --> SP
-    SP --> MR
-    MR --> EP
-    MR --> EKS
-    EP --> MM
-    EKS --> ALB
-    MM --> CW
-    SF --> SP
-    EXP --> RDS
-```
-
-## 🔄 ML Lifecycle Management
-
-```mermaid
-flowchart LR
-    A[Data Ingestion] --> B[Feature Engineering]
-    B --> C[Model Training]
-    C --> D[Model Validation]
-    D --> E{Quality Gate}
-    E -->|Pass| F[Model Registration]
-    E -->|Fail| G[Retrain]
-    G --> C
-    F --> H[Staging Deployment]
-    H --> I[A/B Testing]
-    I --> J{Performance OK?}
-    J -->|Yes| K[Production Deployment]
-    J -->|No| L[Rollback]
-    K --> M[Monitoring]
-    M --> N{Drift Detected?}
-    N -->|Yes| O[Alert]
-    N -->|No| M
-    O --> P[Auto Retrain]
-    P --> C
-```
-
-## 🎯 Key Features
-
-### 🔧 **Infrastructure as Code**
-- Complete Terraform modules for all AWS ML services
-- Multi-environment support (dev/stage/prod)
-- Automated resource provisioning and scaling
-
-### 🤖 **Automated ML Pipelines**
-- SageMaker Pipelines for training workflows
-- Step Functions for complex orchestration
-- EventBridge-triggered automated retraining
-
-### 📊 **Model Management**
-- Centralized model registry with versioning
-- A/B testing infrastructure
-- Blue/green deployment strategies
-
-### 📈 **Monitoring & Observability**
-- Real-time model performance monitoring
-- Data drift detection and alerting
-- Comprehensive logging and tracing
-
-### 🔒 **Security & Compliance**
-- IAM roles with principle of least privilege
-- VPC isolation and network security
-- Encryption at rest and in transit
-
-## 📁 Repository Structure
+## Repository layout
 
 ```
 ml-platform-aws/
-├── modules/
-│   ├── sagemaker-platform/     # Core SageMaker infrastructure
-│   ├── ml-pipelines/           # Training and inference pipelines
-│   └── model-serving/          # Model deployment infrastructure
-├── infrastructure/
-│   ├── environments/
-│   │   ├── dev/               # Development environment
-│   │   ├── stage/             # Staging environment
-│   │   └── prod/              # Production environment
-│   └── shared/                # Shared resources
-├── examples/
-│   ├── end-to-end-ml-pipeline/ # Complete ML workflow example
-│   └── model-deployment/       # Model serving examples
-├── docs/
-│   ├── architecture/          # Architecture documentation
-│   └── tutorials/             # Step-by-step guides
-├── scripts/                   # Utility scripts
-└── tests/                     # Infrastructure tests
+  modules/
+    sagemaker-platform/   # the module
+      main.tf
+      iam.tf
+      variables.tf
+      outputs.tf
+      versions.tf
+  examples/
+    basic/                # minimal usage example
+  .github/
+    workflows/terraform.yml
+    dependabot.yml
 ```
 
-## 🚀 Quick Start
+There are no other modules, environments, pipelines, EKS clusters, or test
+suites in this repo. The previous README claimed those existed; it was
+aspirational and has been removed.
 
-### Prerequisites
-- AWS CLI configured with appropriate permissions
-- Terraform >= 1.8.0
-- Docker (for local testing)
-- Python 3.9+ (for Lambda functions)
+## Requirements
 
-### 1. Deploy Core Infrastructure
+| Tool          | Version  |
+|---------------|----------|
+| Terraform     | >= 1.9.0 |
+| AWS provider  | ~> 6.0   |
 
-```bash
-# Clone the repository
-git clone https://github.com/melorga/ml-platform-aws.git
-cd ml-platform-aws
+You will need an AWS account, a VPC with at least two private subnets, and
+credentials with permission to create SageMaker, IAM, S3, KMS, CloudWatch,
+EventBridge, Lambda, and SNS resources.
 
-# Deploy to development environment
-cd infrastructure/environments/dev
-terraform init
-terraform plan
-terraform apply
+## Usage
+
+```hcl
+module "sagemaker_platform" {
+  source = "github.com/melorga/ml-platform-aws//modules/sagemaker-platform"
+
+  project_name = "ml-demo"
+  domain_name  = "ml-demo-studio"
+  environment  = "dev"
+
+  vpc_id     = "vpc-0123456789abcdef0"
+  subnet_ids = ["subnet-aaa", "subnet-bbb"]
+
+  user_profiles        = ["data-scientist", "ml-engineer"]
+  model_package_groups = ["classification-models"]
+
+  tags = {
+    Project = "ml-demo"
+    Owner   = "platform"
+  }
+}
 ```
 
-### 2. Run Example ML Pipeline
+A runnable example is in [`examples/basic/`](./examples/basic/).
 
-```bash
-# Deploy example pipeline
-cd examples/end-to-end-ml-pipeline
-terraform init
-terraform apply
+## Inputs
 
-# Execute training pipeline
-aws stepfunctions start-execution \
-  --state-machine-arn $(terraform output pipeline_arn) \
-  --input '{}'
-```
+See [`modules/sagemaker-platform/variables.tf`](./modules/sagemaker-platform/variables.tf)
+for the full input schema and validation rules. Notable defaults:
 
-### 3. Monitor Pipeline Execution
+- `default_instance_type = "ml.t3.medium"` (validated against a list that
+  includes m5/m6i, c5/c6i, Graviton m7g/c7g, and g5 families)
+- `log_retention_days = 30`
+- `enable_model_monitoring = true`
 
-```bash
-# View pipeline status
-aws stepfunctions describe-execution \
-  --execution-arn <execution-arn>
+## Outputs
 
-# Check model registry
-aws sagemaker list-model-packages \
-  --model-package-group-name demo-model-group
-```
+See [`modules/sagemaker-platform/outputs.tf`](./modules/sagemaker-platform/outputs.tf).
+Includes Studio domain ID/ARN/URL, bucket names/ARNs, KMS key ID/ARN, IAM
+role ARNs, log group names, SNS topic ARN, and a flattened `sagemaker_config`
+object for chaining into downstream modules.
 
-## 🛠️ Infrastructure Modules
+## CI
 
-### SageMaker Platform Module
+A GitHub Actions workflow runs on every PR and push to `main`:
 
-**Location**: `modules/sagemaker-platform/`
+- `terraform fmt -check -recursive`
+- `terraform validate` against `examples/basic`
+- [`tflint`](https://github.com/terraform-linters/tflint) recursive
+- [`trivy config`](https://github.com/aquasecurity/trivy-action) with SARIF
+  upload to GitHub Security
 
-**Components**:
-- SageMaker Studio Domain with user profiles
-- Feature Store for feature management
-- Model Registry for model versioning
-- Processing and training job configurations
+## Caveats
 
-### ML Pipelines Module
+- The module assumes the VPC and private subnets already exist.
+- The Lambda alert handler is intentionally a placeholder; it publishes a
+  formatted message to SNS but does no triage.
+- `aws_sagemaker_domain` can take 5-10 minutes to create or destroy.
+- This is a reference implementation. Review the IAM policies and KMS
+  resource policy against your own threat model before using in production.
 
-**Location**: `modules/ml-pipelines/`
+## License
 
-**Components**:
-- Step Functions state machines
-- SageMaker Pipeline definitions
-- EventBridge rules for automation
-- Lambda functions for orchestration
-
-### Model Serving Module
-
-**Location**: `modules/model-serving/`
-
-**Components**:
-- SageMaker real-time endpoints
-- EKS cluster for batch inference
-- Auto-scaling configurations
-- Load balancers and networking
-
-## 📊 Cost Optimization
-
-### Estimated Monthly Costs (USD)
-
-| Component | Dev | Stage | Prod |
-|-----------|-----|-------|------|
-| SageMaker Studio | $50 | $100 | $200 |
-| Training Jobs | $100 | $300 | $800 |
-| Endpoints | $200 | $500 | $1,500 |
-| EKS Cluster | $150 | $300 | $600 |
-| Storage (S3/EFS) | $20 | $50 | $150 |
-| **Total** | **$520** | **$1,250** | **$3,250** |
-
-### Cost Optimization Features
-- Spot instances for training jobs
-- Auto-scaling for endpoints
-- Lifecycle policies for data storage
-- Scheduled shutdown for development resources
-
-## 🔐 Security Features
-
-- **Identity & Access Management**
-  - Fine-grained IAM roles and policies
-  - Resource-based permissions
-  - Cross-account access controls
-
-- **Network Security**
-  - VPC isolation with private subnets
-  - Security groups and NACLs
-  - VPC endpoints for AWS services
-
-- **Data Protection**
-  - Encryption at rest (S3, EBS, RDS)
-  - Encryption in transit (TLS/SSL)
-  - Key management with AWS KMS
-
-- **Compliance**
-  - CloudTrail logging
-  - Config rules for compliance monitoring
-  - GuardDuty for threat detection
-
-## 📈 Performance Metrics
-
-### Training Performance
-- **Model Training Time**: 15-45 minutes (depending on data size)
-- **Pipeline Execution Time**: 2-8 hours (end-to-end)
-- **Resource Utilization**: 85-95% (optimized instance types)
-
-### Inference Performance
-- **Real-time Latency**: <100ms (P99)
-- **Batch Throughput**: 10K+ predictions/minute
-- **Availability**: 99.9% SLA
-
-## 🧪 Testing
-
-```bash
-# Run infrastructure tests
-cd tests
-go test -v ./...
-
-# Run integration tests
-python -m pytest tests/integration/
-
-# Performance testing
-cd scripts
-./load_test.sh
-```
-
-## 📚 Documentation
-
-- [Architecture Deep Dive](docs/architecture/README.md)
-- [Deployment Guide](docs/tutorials/deployment.md)
-- [ML Pipeline Tutorial](docs/tutorials/ml-pipeline.md)
-- [Monitoring Guide](docs/tutorials/monitoring.md)
-- [Troubleshooting](docs/tutorials/troubleshooting.md)
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests for new functionality
-5. Run the test suite
-6. Submit a pull request
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🏆 Portfolio Impact
-
-This MLOps platform demonstrates:
-
-✅ **Enterprise-grade ML infrastructure** design and implementation  
-✅ **Advanced AWS services integration** (SageMaker, EKS, Step Functions)  
-✅ **Infrastructure as Code** best practices with Terraform  
-✅ **MLOps pipeline automation** with CI/CD integration  
-✅ **Cost optimization** and performance engineering  
-✅ **Security and compliance** in ML workloads  
-
----
-
-**Built with ❤️ by [melorga](https://github.com/melorga) as part of an advanced AWS Solutions Architect portfolio**
+MIT - see [LICENSE](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is an experimental, single-module reference implementation.
+There are no released versions and no security support guarantees. Pin to a
+specific commit SHA if you depend on it.
+
+## Reporting a Vulnerability
+
+If you discover a security issue (a misconfigured IAM policy, a leaked
+credential pattern, an insecure default, etc.), please **do not** open a
+public GitHub issue.
+
+Instead, report it privately via GitHub's [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+feature on this repository, or email the maintainer listed in `CODEOWNERS`.
+
+Please include:
+
+- A description of the issue and its impact
+- Steps to reproduce or a proof of concept
+- Any suggested remediation
+
+You should expect an initial acknowledgement within 7 days.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,55 @@
+# Basic example: deploys the sagemaker-platform module against an existing VPC.
+#
+# Prerequisites:
+#   - An AWS account and credentials available to the AWS provider
+#   - An existing VPC with at least two private subnets
+#
+# Usage:
+#   terraform init
+#   terraform plan -var="vpc_id=vpc-xxx" -var='subnet_ids=["subnet-a","subnet-b"]'
+#   terraform apply
+
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming."
+  type        = string
+  default     = "ml-demo"
+}
+
+variable "vpc_id" {
+  description = "Existing VPC ID where SageMaker Studio will be deployed."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Two or more private subnet IDs in the VPC above."
+  type        = list(string)
+}
+
+module "sagemaker_platform" {
+  source = "../../modules/sagemaker-platform"
+
+  project_name = var.project_name
+  domain_name  = "${var.project_name}-studio"
+  environment  = "dev"
+
+  vpc_id     = var.vpc_id
+  subnet_ids = var.subnet_ids
+
+  default_instance_type = "ml.t3.medium"
+  user_profiles         = ["data-scientist", "ml-engineer"]
+  model_package_groups  = ["classification-models"]
+
+  enable_model_monitoring = true
+  log_retention_days      = 30
+
+  tags = {
+    Owner       = "platform"
+    Environment = "dev"
+  }
+}

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,0 +1,34 @@
+output "sagemaker_domain_id" {
+  description = "ID of the SageMaker Studio Domain."
+  value       = module.sagemaker_platform.sagemaker_domain_id
+}
+
+output "sagemaker_domain_url" {
+  description = "URL of the SageMaker Studio Domain."
+  value       = module.sagemaker_platform.sagemaker_domain_url
+}
+
+output "sagemaker_bucket_name" {
+  description = "Name of the S3 bucket for SageMaker artifacts."
+  value       = module.sagemaker_platform.sagemaker_bucket_name
+}
+
+output "feature_store_bucket_name" {
+  description = "Name of the S3 bucket backing the Feature Store offline store."
+  value       = module.sagemaker_platform.feature_store_bucket_name
+}
+
+output "sagemaker_kms_key_arn" {
+  description = "ARN of the KMS key encrypting SageMaker resources."
+  value       = module.sagemaker_platform.sagemaker_kms_key_arn
+}
+
+output "sagemaker_execution_role_arn" {
+  description = "ARN of the SageMaker execution role."
+  value       = module.sagemaker_platform.sagemaker_execution_role_arn
+}
+
+output "model_monitor_alerts_topic_arn" {
+  description = "SNS topic ARN that receives Model Monitor alerts."
+  value       = module.sagemaker_platform.model_monitor_alerts_topic_arn
+}

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "ml-platform-aws-example"
+      ManagedBy = "Terraform"
+      Example   = "basic"
+    }
+  }
+}

--- a/modules/sagemaker-platform/iam.tf
+++ b/modules/sagemaker-platform/iam.tf
@@ -1,4 +1,10 @@
 # IAM Roles and Policies for SageMaker Platform
+#
+# Note: We deliberately do NOT attach the AWS-managed AmazonSageMakerFullAccess
+# policy. That policy is broad (s3:*, ecr:*, iam:PassRole on *, etc.) and is
+# not appropriate for production. The inline policy below is the least-privilege
+# replacement and only grants access to the buckets, KMS key, log groups, ECR
+# repositories, and SNS topic provisioned by this module.
 
 # SageMaker Execution Role
 resource "aws_iam_role" "sagemaker_execution" {
@@ -22,13 +28,8 @@ resource "aws_iam_role" "sagemaker_execution" {
   })
 }
 
-# Attach AWS managed policy for SageMaker execution
-resource "aws_iam_role_policy_attachment" "sagemaker_execution_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
-  role       = aws_iam_role.sagemaker_execution.name
-}
-
-# Custom policy for SageMaker execution with specific permissions
+# Custom least-privilege policy for SageMaker execution.
+# Replaces AmazonSageMakerFullAccess; resources are scoped to module-owned ARNs.
 resource "aws_iam_role_policy" "sagemaker_execution_custom" {
   name = "${var.project_name}-sagemaker-execution-custom"
   role = aws_iam_role.sagemaker_execution.id
@@ -82,14 +83,20 @@ resource "aws_iam_role_policy" "sagemaker_execution_custom" {
         ]
       },
       {
+        # ecr:GetAuthorizationToken cannot be resource-scoped (ECR API quirk),
+        # everything else is scoped to repositories in this account.
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
         Effect = "Allow"
         Action = [
-          "ecr:GetAuthorizationToken",
           "ecr:BatchCheckLayerAvailability",
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage"
         ]
-        Resource = "*"
+        Resource = "arn:aws:ecr:*:${data.aws_caller_identity.current.account_id}:repository/*"
       },
       {
         Effect = "Allow"

--- a/modules/sagemaker-platform/main.tf
+++ b/modules/sagemaker-platform/main.tf
@@ -326,7 +326,7 @@ resource "aws_lambda_function" "model_monitor_processor" {
   function_name = "${var.project_name}-model-monitor-processor"
   role          = aws_iam_role.lambda_execution[0].arn
   handler       = "index.handler"
-  runtime       = "python3.12"
+  runtime       = "python3.13"
   timeout       = 300
 
   source_code_hash = data.archive_file.model_monitor_lambda[0].output_base64sha256

--- a/modules/sagemaker-platform/main.tf
+++ b/modules/sagemaker-platform/main.tf
@@ -1,15 +1,6 @@
 # SageMaker Platform Module
-# This module creates a comprehensive SageMaker infrastructure for MLOps
-
-terraform {
-  required_version = ">= 1.8.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
+# Provisions SageMaker Studio, Model Registry, Feature Store buckets, KMS, and
+# an EventBridge -> Lambda alerting pipeline for Model Monitor events.
 
 # Data source for current AWS account and region
 data "aws_caller_identity" "current" {}
@@ -41,21 +32,21 @@ resource "aws_sagemaker_domain" "studio" {
 
   default_user_settings {
     execution_role = aws_iam_role.sagemaker_execution.arn
-    
+
     jupyter_server_app_settings {
       default_resource_spec {
         instance_type       = var.default_instance_type
         sagemaker_image_arn = var.sagemaker_image_arn
       }
     }
-    
+
     kernel_gateway_app_settings {
       default_resource_spec {
         instance_type       = var.default_instance_type
         sagemaker_image_arn = var.sagemaker_image_arn
       }
     }
-    
+
     tensor_board_app_settings {
       default_resource_spec {
         instance_type = "ml.t3.medium"
@@ -70,13 +61,13 @@ resource "aws_sagemaker_domain" "studio" {
 
   default_space_settings {
     execution_role = aws_iam_role.sagemaker_execution.arn
-    
+
     jupyter_server_app_settings {
       default_resource_spec {
         instance_type = var.default_instance_type
       }
     }
-    
+
     kernel_gateway_app_settings {
       default_resource_spec {
         instance_type = var.default_instance_type
@@ -91,13 +82,13 @@ resource "aws_sagemaker_domain" "studio" {
 
 # SageMaker User Profiles
 resource "aws_sagemaker_user_profile" "users" {
-  for_each    = toset(var.user_profiles)
-  domain_id   = aws_sagemaker_domain.studio.id
+  for_each          = toset(var.user_profiles)
+  domain_id         = aws_sagemaker_domain.studio.id
   user_profile_name = each.value
 
   user_settings {
     execution_role = aws_iam_role.sagemaker_execution.arn
-    
+
     jupyter_server_app_settings {
       default_resource_spec {
         instance_type = var.default_instance_type
@@ -147,6 +138,9 @@ resource "aws_s3_bucket_public_access_block" "sagemaker_bucket_pab" {
 }
 
 # KMS Key for SageMaker encryption
+# Root account retains kms:* (standard pattern, prevents key lockout).
+# SageMaker service grant is scoped via kms:ViaService so the key can only be
+# used through the SageMaker control plane, not from arbitrary callers.
 resource "aws_kms_key" "sagemaker_key" {
   description             = "KMS key for SageMaker encryption"
   deletion_window_in_days = 7
@@ -156,7 +150,7 @@ resource "aws_kms_key" "sagemaker_key" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "Enable IAM User Permissions"
+        Sid    = "EnableRootAccountAdmin"
         Effect = "Allow"
         Principal = {
           AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
@@ -165,7 +159,7 @@ resource "aws_kms_key" "sagemaker_key" {
         Resource = "*"
       },
       {
-        Sid    = "Allow SageMaker Service"
+        Sid    = "AllowSageMakerServiceScoped"
         Effect = "Allow"
         Principal = {
           Service = "sagemaker.amazonaws.com"
@@ -178,6 +172,11 @@ resource "aws_kms_key" "sagemaker_key" {
           "kms:DescribeKey"
         ]
         Resource = "*"
+        Condition = {
+          StringLike = {
+            "kms:ViaService" = "sagemaker.*.amazonaws.com"
+          }
+        }
       }
     ]
   })
@@ -194,8 +193,8 @@ resource "aws_kms_alias" "sagemaker_key_alias" {
 
 # Model Registry (Model Package Groups)
 resource "aws_sagemaker_model_package_group" "model_groups" {
-  for_each                    = toset(var.model_package_groups)
-  model_package_group_name    = each.value
+  for_each                        = toset(var.model_package_groups)
+  model_package_group_name        = each.value
   model_package_group_description = "Model package group for ${each.value} models"
 
   tags = merge(var.tags, {
@@ -306,16 +305,29 @@ resource "aws_sns_topic" "model_monitor_alerts" {
   })
 }
 
+# Lambda log group with explicit retention (avoids implicit infinite retention)
+resource "aws_cloudwatch_log_group" "model_monitor_lambda" {
+  count = var.enable_model_monitoring ? 1 : 0
+
+  name              = "/aws/lambda/${var.project_name}-model-monitor-processor"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = aws_kms_key.sagemaker_key.arn
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-model-monitor-lambda-logs"
+  })
+}
+
 # Lambda function for processing model monitor alerts (placeholder)
 resource "aws_lambda_function" "model_monitor_processor" {
   count = var.enable_model_monitoring ? 1 : 0
-  
-  filename         = "model_monitor_lambda.zip"
-  function_name    = "${var.project_name}-model-monitor-processor"
-  role            = aws_iam_role.lambda_execution[0].arn
-  handler         = "index.handler"
-  runtime         = "python3.9"
-  timeout         = 300
+
+  filename      = "model_monitor_lambda.zip"
+  function_name = "${var.project_name}-model-monitor-processor"
+  role          = aws_iam_role.lambda_execution[0].arn
+  handler       = "index.handler"
+  runtime       = "python3.12"
+  timeout       = 300
 
   source_code_hash = data.archive_file.model_monitor_lambda[0].output_base64sha256
 
@@ -326,6 +338,8 @@ resource "aws_lambda_function" "model_monitor_processor" {
     }
   }
 
+  depends_on = [aws_cloudwatch_log_group.model_monitor_lambda]
+
   tags = merge(var.tags, {
     Name = "${var.project_name}-model-monitor-processor"
   })
@@ -334,12 +348,12 @@ resource "aws_lambda_function" "model_monitor_processor" {
 # Lambda deployment package
 data "archive_file" "model_monitor_lambda" {
   count = var.enable_model_monitoring ? 1 : 0
-  
+
   type        = "zip"
   output_path = "model_monitor_lambda.zip"
-  
+
   source {
-    content = <<EOF
+    content  = <<EOF
 import json
 import boto3
 import os
@@ -356,35 +370,32 @@ def handler(event, context):
     """
     try:
         logger.info(f"Received event: {json.dumps(event)}")
-        
-        # Extract monitoring execution details
+
         detail = event.get('detail', {})
         execution_status = detail.get('MonitoringExecutionStatus')
         execution_arn = detail.get('MonitoringExecutionArn')
-        
-        # Create alert message
+
         message = f"""
         SageMaker Model Monitor Alert
-        
+
         Status: {execution_status}
         Execution ARN: {execution_arn}
         Time: {event.get('time')}
-        
+
         Please check the SageMaker console for detailed results.
         """
-        
-        # Send SNS notification
+
         sns.publish(
             TopicArn=os.environ['SNS_TOPIC_ARN'],
             Subject=f"Model Monitor Alert - {execution_status}",
             Message=message
         )
-        
+
         return {
             'statusCode': 200,
             'body': json.dumps('Alert processed successfully')
         }
-        
+
     except Exception as e:
         logger.error(f"Error processing alert: {str(e)}")
         return {
@@ -399,7 +410,7 @@ EOF
 # EventBridge Target for Lambda
 resource "aws_cloudwatch_event_target" "model_monitor_lambda_target" {
   count = var.enable_model_monitoring ? 1 : 0
-  
+
   rule      = aws_cloudwatch_event_rule.model_monitor_rule.name
   target_id = "ModelMonitorLambdaTarget"
   arn       = aws_lambda_function.model_monitor_processor[0].arn
@@ -408,7 +419,7 @@ resource "aws_cloudwatch_event_target" "model_monitor_lambda_target" {
 # Lambda permission for EventBridge
 resource "aws_lambda_permission" "allow_eventbridge" {
   count = var.enable_model_monitoring ? 1 : 0
-  
+
   statement_id  = "AllowExecutionFromEventBridge"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.model_monitor_processor[0].function_name

--- a/modules/sagemaker-platform/variables.tf
+++ b/modules/sagemaker-platform/variables.tf
@@ -3,7 +3,7 @@
 variable "project_name" {
   description = "Name of the project. Used for resource naming and tagging."
   type        = string
-  
+
   validation {
     condition     = can(regex("^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$", var.project_name))
     error_message = "Project name must start with a letter, contain only alphanumeric characters and hyphens, and end with an alphanumeric character."
@@ -14,7 +14,7 @@ variable "domain_name" {
   description = "Name for the SageMaker Studio Domain"
   type        = string
   default     = ""
-  
+
   validation {
     condition     = var.domain_name == "" || can(regex("^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$", var.domain_name))
     error_message = "Domain name must start with a letter, contain only alphanumeric characters and hyphens, and end with an alphanumeric character."
@@ -24,7 +24,7 @@ variable "domain_name" {
 variable "vpc_id" {
   description = "VPC ID where SageMaker Studio will be deployed"
   type        = string
-  
+
   validation {
     condition     = can(regex("^vpc-[a-z0-9]+$", var.vpc_id))
     error_message = "VPC ID must be a valid AWS VPC identifier."
@@ -34,12 +34,12 @@ variable "vpc_id" {
 variable "subnet_ids" {
   description = "List of subnet IDs for SageMaker Studio (should be private subnets)"
   type        = list(string)
-  
+
   validation {
     condition     = length(var.subnet_ids) >= 2
     error_message = "At least 2 subnet IDs must be provided for high availability."
   }
-  
+
   validation {
     condition     = alltrue([for s in var.subnet_ids : can(regex("^subnet-[a-z0-9]+$", s))])
     error_message = "All subnet IDs must be valid AWS subnet identifiers."
@@ -50,14 +50,25 @@ variable "default_instance_type" {
   description = "Default instance type for SageMaker Studio apps"
   type        = string
   default     = "ml.t3.medium"
-  
+
   validation {
     condition = contains([
+      # Burstable
       "ml.t3.medium", "ml.t3.large", "ml.t3.xlarge", "ml.t3.2xlarge",
+      # General purpose (Intel)
       "ml.m5.large", "ml.m5.xlarge", "ml.m5.2xlarge", "ml.m5.4xlarge",
-      "ml.c5.large", "ml.c5.xlarge", "ml.c5.2xlarge", "ml.c5.4xlarge"
+      "ml.m6i.large", "ml.m6i.xlarge", "ml.m6i.2xlarge", "ml.m6i.4xlarge",
+      # General purpose (Graviton)
+      "ml.m7g.large", "ml.m7g.xlarge", "ml.m7g.2xlarge", "ml.m7g.4xlarge",
+      # Compute optimized (Intel)
+      "ml.c5.large", "ml.c5.xlarge", "ml.c5.2xlarge", "ml.c5.4xlarge",
+      "ml.c6i.large", "ml.c6i.xlarge", "ml.c6i.2xlarge", "ml.c6i.4xlarge",
+      # Compute optimized (Graviton)
+      "ml.c7g.large", "ml.c7g.xlarge", "ml.c7g.2xlarge", "ml.c7g.4xlarge",
+      # GPU
+      "ml.g5.xlarge", "ml.g5.2xlarge", "ml.g5.4xlarge", "ml.g5.8xlarge"
     ], var.default_instance_type)
-    error_message = "Instance type must be a valid SageMaker instance type."
+    error_message = "Instance type must be a valid SageMaker instance type from the supported list (Intel m5/m6i/c5/c6i, Graviton m7g/c7g, GPU g5, or burstable t3)."
   }
 }
 
@@ -71,12 +82,12 @@ variable "user_profiles" {
   description = "List of user profiles to create in SageMaker Studio"
   type        = list(string)
   default     = ["data-scientist", "ml-engineer"]
-  
+
   validation {
     condition     = length(var.user_profiles) > 0
     error_message = "At least one user profile must be specified."
   }
-  
+
   validation {
     condition     = alltrue([for p in var.user_profiles : can(regex("^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$", p))])
     error_message = "User profile names must start with a letter, contain only alphanumeric characters and hyphens, and end with an alphanumeric character."
@@ -87,12 +98,12 @@ variable "model_package_groups" {
   description = "List of model package groups to create for the model registry"
   type        = list(string)
   default     = ["classification-models", "regression-models", "nlp-models"]
-  
+
   validation {
     condition     = length(var.model_package_groups) > 0
     error_message = "At least one model package group must be specified."
   }
-  
+
   validation {
     condition     = alltrue([for g in var.model_package_groups : can(regex("^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$", g))])
     error_message = "Model package group names must start with a letter, contain only alphanumeric characters and hyphens, and end with an alphanumeric character."
@@ -109,7 +120,7 @@ variable "log_retention_days" {
   description = "Number of days to retain CloudWatch logs"
   type        = number
   default     = 30
-  
+
   validation {
     condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.log_retention_days)
     error_message = "Log retention days must be a valid CloudWatch log retention period."
@@ -126,7 +137,7 @@ variable "feature_store_s3_prefix" {
   description = "S3 prefix for Feature Store offline store"
   type        = string
   default     = "feature-store"
-  
+
   validation {
     condition     = can(regex("^[a-zA-Z0-9/_-]+$", var.feature_store_s3_prefix))
     error_message = "S3 prefix must contain only alphanumeric characters, hyphens, underscores, and forward slashes."
@@ -138,7 +149,12 @@ variable "training_instance_types" {
   type        = list(string)
   default = [
     "ml.m5.large", "ml.m5.xlarge", "ml.m5.2xlarge", "ml.m5.4xlarge",
+    "ml.m6i.xlarge", "ml.m6i.2xlarge", "ml.m6i.4xlarge",
+    "ml.m7g.xlarge", "ml.m7g.2xlarge",
     "ml.c5.xlarge", "ml.c5.2xlarge", "ml.c5.4xlarge",
+    "ml.c6i.xlarge", "ml.c6i.2xlarge",
+    "ml.c7g.xlarge", "ml.c7g.2xlarge",
+    "ml.g5.xlarge", "ml.g5.2xlarge", "ml.g5.4xlarge",
     "ml.p3.2xlarge", "ml.p3.8xlarge"
   ]
 }
@@ -147,9 +163,13 @@ variable "endpoint_instance_types" {
   description = "List of allowed instance types for model endpoints"
   type        = list(string)
   default = [
-    "ml.t2.medium", "ml.t2.large", "ml.t2.xlarge",
     "ml.m5.large", "ml.m5.xlarge", "ml.m5.2xlarge",
-    "ml.c5.large", "ml.c5.xlarge", "ml.c5.2xlarge"
+    "ml.m6i.large", "ml.m6i.xlarge", "ml.m6i.2xlarge",
+    "ml.m7g.large", "ml.m7g.xlarge",
+    "ml.c5.large", "ml.c5.xlarge", "ml.c5.2xlarge",
+    "ml.c6i.large", "ml.c6i.xlarge",
+    "ml.c7g.large", "ml.c7g.xlarge",
+    "ml.g5.xlarge", "ml.g5.2xlarge"
   ]
 }
 
@@ -163,7 +183,7 @@ variable "max_capacity" {
   description = "Maximum capacity for auto-scaling endpoints"
   type        = number
   default     = 10
-  
+
   validation {
     condition     = var.max_capacity >= 1 && var.max_capacity <= 100
     error_message = "Maximum capacity must be between 1 and 100."
@@ -174,7 +194,7 @@ variable "min_capacity" {
   description = "Minimum capacity for auto-scaling endpoints"
   type        = number
   default     = 1
-  
+
   validation {
     condition     = var.min_capacity >= 1 && var.min_capacity <= 100
     error_message = "Minimum capacity must be between 1 and 100."
@@ -184,16 +204,16 @@ variable "min_capacity" {
 variable "target_tracking_scaling_policy_configuration" {
   description = "Configuration for target tracking scaling policy"
   type = object({
-    target_value               = number
-    predefined_metric_type     = string
-    scale_out_cooldown        = number
-    scale_in_cooldown         = number
+    target_value           = number
+    predefined_metric_type = string
+    scale_out_cooldown     = number
+    scale_in_cooldown      = number
   })
   default = {
-    target_value               = 70.0
-    predefined_metric_type     = "SageMakerVariantInvocationsPerInstance"
-    scale_out_cooldown        = 300
-    scale_in_cooldown         = 300
+    target_value           = 70.0
+    predefined_metric_type = "SageMakerVariantInvocationsPerInstance"
+    scale_out_cooldown     = 300
+    scale_in_cooldown      = 300
   }
 }
 
@@ -201,7 +221,7 @@ variable "notification_email" {
   description = "Email address for model monitoring notifications"
   type        = string
   default     = ""
-  
+
   validation {
     condition     = var.notification_email == "" || can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.notification_email))
     error_message = "Notification email must be a valid email address."
@@ -218,7 +238,7 @@ variable "data_capture_percentage" {
   description = "Percentage of requests to capture for model monitoring"
   type        = number
   default     = 100
-  
+
   validation {
     condition     = var.data_capture_percentage >= 0 && var.data_capture_percentage <= 100
     error_message = "Data capture percentage must be between 0 and 100."
@@ -229,7 +249,7 @@ variable "model_approval_status" {
   description = "Default approval status for models in the registry"
   type        = string
   default     = "PendingManualApproval"
-  
+
   validation {
     condition     = contains(["Approved", "Rejected", "PendingManualApproval"], var.model_approval_status)
     error_message = "Model approval status must be one of: Approved, Rejected, PendingManualApproval."
@@ -240,7 +260,7 @@ variable "environment" {
   description = "Environment name (dev, stage, prod)"
   type        = string
   default     = "dev"
-  
+
   validation {
     condition     = contains(["dev", "stage", "prod"], var.environment)
     error_message = "Environment must be one of: dev, stage, prod."
@@ -251,7 +271,7 @@ variable "tags" {
   description = "A map of tags to assign to all resources"
   type        = map(string)
   default     = {}
-  
+
   validation {
     condition     = alltrue([for k, v in var.tags : can(regex("^[a-zA-Z0-9\\s_.:/=+\\-@]*$", k)) && can(regex("^[a-zA-Z0-9\\s_.:/=+\\-@]*$", v))])
     error_message = "Tag keys and values must contain only alphanumeric characters, spaces, and the characters _.:/=+-@"

--- a/modules/sagemaker-platform/versions.tf
+++ b/modules/sagemaker-platform/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Portfolio audit pass. Disclosure: this repo's prior README sold an enterprise-grade MLOps platform; the codebase is one Terraform module with a SageMaker Studio scaffold + Lambda alerting. README now reflects reality.

## Critical fix
- **Lambda runtime `python3.9`** would not deploy: AWS blocked new Python 3.9 function creation Dec 2025 and updates Feb 2026. Bumped to **`python3.13`**.

## Module changes
- AWS provider `~> 5.0` → `~> 6.0`; Terraform `>= 1.9.0`. `terraform { ... }` extracted to `versions.tf`.
- IAM tightened: dropped `AmazonSageMakerFullAccess` managed policy in favor of the existing inline policies; narrowed `Resource = "*"` for `ecr:*` to account-scoped repository ARNs; added `kms:ViaService = "sagemaker.*.amazonaws.com"` condition on the SageMaker KMS grant.
- Refreshed instance-type validation lists: added Graviton (`ml.m7g`, `ml.c7g`), `ml.m6i`, `ml.g5`; dropped `ml.t2.*` from endpoint defaults.
- Added explicit `aws_cloudwatch_log_group` for the Lambda (KMS-encrypted, configurable retention).

## Working example
- New `examples/basic/{main,outputs,versions}.tf` so `terraform init && validate` actually works.

## CI
- New `.github/workflows/terraform.yml`: fmt, init+validate against `examples/basic`, tflint, trivy config scan with SARIF upload.
- Top-level `permissions: { contents: read, security-events: write, pull-requests: write }`.
- `concurrency` block. Pinned `terraform_version: 1.15.1`. All actions on current majors.

## README & hygiene
- README rewritten: dropped EKS/Pipelines/multi-env/examples/docs/tests claims; added "Status: experimental, single-module reference implementation" banner; broken `docs/*` links removed.
- New `.gitignore`, `dependabot.yml`, `CODEOWNERS`, `SECURITY.md`.

## Honest assessment
- This is one module dressed as a platform. If the goal is a CV piece, consider either (a) merging this and acknowledging scope, (b) building out actual SageMaker `Pipeline` / `Endpoint` / `MonitoringSchedule` resources, or (c) archiving the repo.

## Test plan
- [ ] CI fmt + validate + tflint + trivy pass on this PR
- [ ] `terraform plan` against `examples/basic` (with sensible vars) produces a valid plan