### PR TITLE
chore(deps): trim Dependabot to monthly + grouped minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     labels:
       - "dependencies"
       - "github-actions"
@@ -12,8 +16,12 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/modules/sagemaker-platform"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      terraform-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     labels:
       - "dependencies"
       - "terraform"
@@ -21,8 +29,12 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/examples/basic"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      terraform-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     labels:
       - "dependencies"
       - "terraform"


### PR DESCRIPTION
## Why

Was weekly with `open-pull-requests-limit: 5` across 3 ecosystems.

## What changes

For all 3 ecosystems (`github-actions`, `terraform /modules/sagemaker-platform`, `terraform /examples/basic`):
- `interval: weekly` → `monthly`
- `open-pull-requests-limit: 5` → `2`
- Add `groups:` so minor/patch updates batch into one PR per ecosystem

Major-version bumps still arrive as individual PRs. Security advisories override the schedule.